### PR TITLE
fix strictqc for maf=NA, update pca_rel final print message

### DIFF
--- a/rp_bin/pca_rel.py
+++ b/rp_bin/pca_rel.py
@@ -297,7 +297,7 @@ elif args.test_sub:
     print 'Completed script. See dummy submit commands above.\n' 
 else:
     print 'Finished submitting jobs.'
-    print 'See bjobs to track job status.'
+    print 'See qstat to track job status.'
     print 'Email will be sent when workflow completes.\n'
 
 exit(0)

--- a/rp_bin/strict_qc.py
+++ b/rp_bin/strict_qc.py
@@ -236,9 +236,12 @@ dumphead = frqs.readline()
 
 for line in frqs:
     (chrom, snp, a1, a2, maf, nobs) = line.split()
+    
+    if str(maf) == "NA":
+        snp_out.write(str(snp) + ' no_MAF\n')
 
-    if float(maf) < args.maf_th or (1.0-float(maf)) < args.maf_th:
-        snp_out.write(snp + ' low_MAF\n')
+    elif float(maf) < args.maf_th or (1.0-float(maf)) < args.maf_th:
+        snp_out.write(str(snp) + ' low_MAF\n')
 
 frqs.close()
 


### PR DESCRIPTION
Pull minor bugfixes from 'dev'
- change final print statement in `pca_rel.py` to suggest `qstat` rather than `bjobs` now that it runs on UGER
- handle MAF=NA in `strictqc.py` 
