### PR TITLE
fix poor phenotype handling from plink --gen

### DIFF
--- a/rp_bin/bg_imp.py
+++ b/rp_bin/bg_imp.py
@@ -364,7 +364,7 @@ cchr=`awk -v a=${{SGE_TASK_ID}} 'NR==a+1{{print $1}}' {cfile}`
 {plink_ex} --gen {gen_in} --sample {samp_in} --oxford-single-chr ${{cchr}} --oxford-pheno-name plink_pheno --hard-call-threshold {hard_call_th} --missing-code -9,NA,na --allow-no-sex --silent --memory 4000 --out {out_str} 
 
 sleep {sleep}
-{plink_ex} --bfile {out_str} {mendel_txt} {info_txt} --allow-no-sex --make-bed --silent --memory 2000 --out {out_str2}
+{plink_ex} --bfile {out_str} {mendel_txt} {info_txt} --pheno {idnum} --mpheno 4 --allow-no-sex --make-bed --silent --memory 2000 --out {out_str2}
 rm {out_str}.bed
 rm {out_str}.bim
 rm {out_str}.fam
@@ -404,6 +404,7 @@ jobdict = {"jname": 'bg.chunks.'+str(outdot),
            "rs_ex": str(rs_ex),
            "outdot": str(outdot),
            "imp_dir": str(imp_dir),
+           "idnum": str(shape_dir)+'/'+str(args.bfile)+'.hg19.ch.fl.fam',
            "trans": str(shape_dir)+'/'+str(args.bfile)+'.hg19.ch.fl.fam.transl'
            }
 


### PR DESCRIPTION
Plink `--gen` unnecessarily tries to recode phenotypes from the `.sample` file, changing -9/1/2 to -9,2,-9. Edit here fixes that by re-adding the correct phenotype from the (shortened/numeric) pre-imputation fam file as part of the post-processing for best-guess.

(Note: the `.sample` files still have the correct phenotype from the input data for imputation, so no changes needed there)
