### PR TITLE
Gmmat

### DIFF
--- a/bin/agg_gwas.py
+++ b/bin/agg_gwas.py
@@ -237,7 +237,7 @@ chnames = [k for k, v in sorted(chunks.iteritems(), key=lambda (key,value): floa
 # bim
 # for gee: a2
 # for dfam: bp
-if args.model == 'gee':
+if args.model == 'gee' or args.model == 'gmmat' or args.model == 'gmmat-fam':
     a2_info = {}
 elif args.model == 'dfam':
     bp_info = {}
@@ -246,7 +246,7 @@ bim = open(bim_file, 'r')
 for line in bim:
     (chrom, snp, cm, bp, a1, a2) = line.split()
     
-    if args.model == 'gee':
+    if args.model == 'gee' or args.model == 'gmmat' or args.model == 'gmmat-fam':
         a2_info[str(snp)] = str(a2)
     elif args.model == 'dfam':
         bp_info[str(snp)] = int(bp)
@@ -291,12 +291,13 @@ if args.info_file is not None:
 out_file = gzip.open(outname, 'wb')
 filt_file = gzip.open(filtoutname+'.tmp.gz', 'wb')
 
-if args.model == 'gee':
+if args.model == 'gee' or args.model == 'gmmat' or args.model == 'gmmat-fam':
     out_head = ['CHR', 'SNP', 'BP', 'A1', 'A2', 'FRQ_A', 'FRQ_U', 'INFO', 'BETA', 'SE', 'CHISQ', 'P', 'N_CAS', 'N_CON', 'ngt']
     filt_head = out_head
 elif args.model == 'dfam':
     out_head = ['CHR', 'SNP', 'BP', 'A1', 'A2', 'FRQ_A', 'FRQ_U', 'INFO', 'OBSERVED', 'EXPECTED', 'CHISQ', 'P', 'N_CAS', 'N_CON', 'ngt']
-    filt_head = out_head  
+    filt_head = out_head
+
 
 # header
 out_file.write('\t'.join(out_head) + '\n')
@@ -311,10 +312,16 @@ for ch in chnames:
     elif args.model == 'dfam':
         chunk_res = open('dfam.'+str(outdot)+'.'+str(ch)+'.dfam', 'r')
         dumphead = chunk_res.readline()
+    elif args.model == 'gmmat':
+        chunk_res = open('gmmat.'+str(outdot)+'.'+str(ch)+'.R.txt', 'r')
+        dumphead = chunk_res.readline()          
+    elif args.model == 'gmmat-fam':
+        chunk_res = open('gmmatfam.'+str(outdot)+'.'+str(ch)+'.R.txt', 'r')
+        dumphead = chunk_res.readline()       
     
     for line in chunk_res:
         # read results
-        if args.model == 'gee':
+        if args.model == 'gee' or args.model == 'gmmat' or args.model == 'gmmat-fam':
             (chrom, snp, bp, a1, beta, se, chisq, p, n, m) = line.split()
             a2 = a2_info.pop(str(snp))
             
@@ -353,7 +360,7 @@ for ch in chnames:
             
  
         # construct output
-        if args.model == 'gee':
+        if args.model == 'gee' or args.model == 'gmmat' or args.model == 'gmmat-fam':
             # ditch gee results with implausible SEs (likely errors / numerical instability)
             if str(se) == 'NA' or float(se) > float(args.max_se):
                 continue

--- a/bin/agg_gwas.py
+++ b/bin/agg_gwas.py
@@ -71,8 +71,8 @@ arg_file.add_argument('--freq-file',
 
 arg_other.add_argument('--model', 
                     type=str.lower,
-                    choices=['dfam','gee'],
-                    help='Which GWAS testing method was used. Current options are plink \'--dfam\' (generalized TDT-alike) or GEE (generalized estimating equations)',
+                    choices=['dfam','gee','gmmat','gmmat-fam'],
+                    help='Which GWAS testing method was used. Current options are plink \'--dfam\' (generalized TDT-alike), GEE (generalized estimating equations), GMMAT (logistic mixed model with GRM for variance component), or GMMAT-fam (logistic mixed model with GRM and family clusters).',
                     required=False,
                     default='gee')
 

--- a/bin/agg_gwas.py
+++ b/bin/agg_gwas.py
@@ -38,7 +38,7 @@ import argparse
 import gzip
 # from warnings import warn
 # from glob import glob
-from math import log10
+from math import log10, sqrt
 from args_gwas import *
 from py_helpers import unbuffer_stdout, file_len
 # , read_conf, link
@@ -127,6 +127,10 @@ for line in chunks_in:
         ch_out = 'gee.'+str(outdot)+'.'+str(chname)+'.auto.R'
     elif args.model == 'dfam':
         ch_out = 'dfam.'+str(outdot)+'.'+str(chname)+'.dfam'
+    elif args.model == 'gmmat':
+    	ch_out = 'gmmat_score.'+str(outdot)+'.'+str(chname)+'.R.txt'
+    elif args.model == 'gmmat-fam':
+   	ch_out = 'gmmatfam_score.'+str(outdot)+'.'+str(chname)+'.R.txt'
     
     # record chunks with no output
     if not os.path.isfile(ch_out):

--- a/bin/args_gwas.py
+++ b/bin/args_gwas.py
@@ -64,7 +64,7 @@ arg_subset = parsergwas.add_argument_group('Analysis Subset')
 
 arg_test.add_argument('--model', 
                     type=str.lower,
-                    choices=['dfam','gee'],
+                    choices=['dfam','gee','gmmat','gmmat-fam'],
                     help='which GWAS testing method to use for family data. Current options are plink \'--dfam\' (generalized TDT-alike) or GEE (generalized estimating equations)',
                     required=False,
                     default='gee')
@@ -191,6 +191,12 @@ arg_exloc.add_argument('--r-ex',
                     type=str,
                     metavar='PATH',
                     help='path to R executable, tries reading from PATH if unspecified',
+                    required=False,
+                    default=None)
+arg_exloc.add_argument('--rscript-ex',
+                    type=str,
+                    metavar='PATH',
+                    help='path to Rscript executable, tries reading from PATH if unspecified',
                     required=False,
                     default=None)
 arg_exloc.add_argument('--rplink-ex',

--- a/bin/args_gwas.py
+++ b/bin/args_gwas.py
@@ -89,6 +89,12 @@ arg_test.add_argument('--covar-number',
                     metavar='COL',
                     help='which columns to use from covariate file (numbered from third column). Passed directly to plink.',
                     required=False)
+arg_test.add_argument('--strict-bfile',
+                      type=str,
+		      metavar='FILESTEM',
+		      help='(GMMAT model only) file stem for input plink bed/bim/fam used to compute GRM. ' + \
+		           'Defaults to using --bfile with MAF > .01, missing < .01 if unspecified.',
+		      required=True)
 arg_subset.add_argument('--keep',
                     type=str,
                     metavar='FILE',

--- a/bin/args_gwas.py
+++ b/bin/args_gwas.py
@@ -34,6 +34,12 @@ arg_base.add_argument('--bfile',
                     metavar='FILESTEM',
                     help='file stem for input plink bed/bim/fam',
                     required=True)
+arg_base.add_argument('--strict-bfile', 
+                    type=str,
+                    metavar='FILESTEM',
+                    help='(GMMAT model only) file stem for input plink bed/bim/fam used to compute GRM. ' + \
+                    'Defaults to using --bfile with MAF > .01, missing < .01 if unspecified.',
+                    required=True)
 arg_base.add_argument('--out',
                     type=str,
                     metavar='OUTNAME',

--- a/bin/args_gwas.py
+++ b/bin/args_gwas.py
@@ -34,12 +34,6 @@ arg_base.add_argument('--bfile',
                     metavar='FILESTEM',
                     help='file stem for input plink bed/bim/fam',
                     required=True)
-arg_base.add_argument('--strict-bfile', 
-                    type=str,
-                    metavar='FILESTEM',
-                    help='(GMMAT model only) file stem for input plink bed/bim/fam used to compute GRM. ' + \
-                    'Defaults to using --bfile with MAF > .01, missing < .01 if unspecified.',
-                    required=True)
 arg_base.add_argument('--out',
                     type=str,
                     metavar='OUTNAME',

--- a/bin/gmmat_logit_covar.R
+++ b/bin/gmmat_logit_covar.R
@@ -130,7 +130,7 @@ out <- data.frame(CHR=f0$CHR,
 		  M_COV=ncol(dat)-1)
 
 # return
-outfile = paste(outstem,".gmmat.R.txt",sep="")
+outfile = paste("gmmatfam.",outstem,".R.txt",sep="")
 write.table(format(out,digits=8), file=outfile, col.names=TRUE, row.names=FALSE, quote=FALSE, sep = ' ')
 
 if(testing){

--- a/bin/gmmat_logit_covar.R
+++ b/bin/gmmat_logit_covar.R
@@ -1,0 +1,140 @@
+#####################
+# Logistic Mixed Model, using GMMAT
+# - logistic link function
+# - GRM + FID clusters (block diagonal) as variance components
+# - arbitrary covariates
+# - see GMMAT package for references
+#
+# by Raymond Walters
+# May 2016
+#
+# Note: currently no check for invariant covariates 
+#
+#####################
+
+testing <- TRUE
+
+require("GMMAT",lib="~/Rlibs")
+
+# need:
+# plink file stem
+# grm file name (assumed square, with same FID/IIDs as bfile (in order)
+# covar file name (file must have header, with FID and IID)
+# outname
+
+# build:
+# fam_clust
+# list of SNPs
+# order of IDs
+# output file name
+
+# parse arguments
+args = commandArgs(TRUE)
+bfile = as.character(args[1])
+grmfile = as.character(args[2])
+covfile = as.character(args[3])
+outstem = as.character(args[4])
+
+if(testing){
+	print(date())
+	print(args)
+}
+
+# load files
+GRM <- as.matrix(read.table(grmfile))
+fam <- read.table(paste(bfile,".fam",sep=""),stringsAsFactors=FALSE,header=FALSE)
+bim <- read.table(paste(bfile,".bim",sep=""),stringsAsFactors=FALSE,header=FALSE)
+snplist <- bim[,2]
+incov <- as.data.frame(read.table(covfile,header=TRUE))
+
+if(testing){
+	print(date())
+}
+
+# verify GRM is square, same dim as fam
+if(ncol(GRM) != nrow(GRM)){
+	stop("GRM matrix must be square. See e.g. 'plink --make-rel square gz', rather than '--make-grm-gz'.")
+}
+if(nrow(GRM) != nrow(fam)){
+	stop("GRM file should match plink fam file (e.g. number, order of individuals)")
+}
+
+# match ID order
+fam_id <- paste(fam[,1], ":", fam[,2], sep="")
+cov_id <- paste(incov$FID, ":", incov$IID, sep="")
+idx <- match(fam_id, cov_id)
+idna <- is.na(idx)
+
+# build covariate/phenotype matrix
+dat <- as.data.frame(matrix(NA,nrow(fam),ncol(incov)-1))
+colnames(dat) <- c("Y",colnames(incov[,-c(1,2)]))
+dat$Y <- fam[,6]
+dat$Y[dat$Y == -9] <- NA
+dat$Y <- dat$Y - 1 # switch from 1/2 to 0/1 coding 
+dat[!idna,-1] <- incov[idx[!idna],-c(1,2)]
+
+if(testing){
+	print(date())
+	print(dim(dat))
+	print(head(dat))
+}
+
+# build fam_clust
+# block diagonal matrix, indicating IDs in same FID
+fam_clust <- matrix(NA,nrow(fam),nrow(fam))
+for(i in 1:nrow(fam)){
+	for(j in 1:i){
+		if(fam[i,1]==fam[j,1]){
+			fam_clust[i,j] <- 1
+		}else{
+			fam_clust[i,j] <- 0
+		}
+	}
+}
+fam_clust[upper.tri(fam_clust)] <- t(fam_clust)[upper.tri(fam_clust)]
+diag(fam_clust) <- 1
+
+if(testing){
+	print(date())
+}
+
+# fit model
+f0 <- glmm.wald(fixed = Y~.,
+		data=dat,
+		kins=list(GRM, fam_clust),
+		family=binomial(link="logit"),
+		infile=bfile,
+		snps=snplist,
+		missing.method="omit")
+
+if(testing){
+	print(date())
+	print(head(f0))
+	print(summary(f0$converged))
+}
+
+# return NA for non-converged results
+f0[!f0$converged | is.na(f0$converged),c("BETA","SE","PVAL")] <- NA
+
+# format output
+# flip beta since gmmat returns results for A2 instead of A1
+out <- data.frame(CHR=f0$CHR, 
+		  SNP=f0$SNP, 
+		  POS=f0$POS, 
+		  A1=f0$A1, 
+		  BETA=-1*f0$BETA, 
+		  SE=f0$SE, 
+		  CHISQ=(f0$BETA/f0$SE)^2, 
+		  P=f0$PVAL, 
+		  N=f0$N, 
+		  M_COV=ncol(dat)-1)
+
+# return
+outfile = paste(outstem,".gmmat.R.txt",sep="")
+write.table(format(out,digits=8), file=outfile, col.names=TRUE, row.names=FALSE, quote=FALSE, sep = ' ')
+
+if(testing){
+	print(date())
+}
+
+# eof

--- a/bin/gmmat_logit_covar.R
+++ b/bin/gmmat_logit_covar.R
@@ -12,7 +12,7 @@
 #
 #####################
 
-testing <- TRUE
+testing <- FALSE
 
 require("GMMAT",lib="~/Rlibs")
 

--- a/bin/gmmat_logit_covar_grmonly.R
+++ b/bin/gmmat_logit_covar_grmonly.R
@@ -98,41 +98,26 @@ if(testing){
 	print(date())
 }
 
-# fit model
-f0 <- glmm.wald(fixed = Y~.,
-		data=dat,
-#		kins=list(GRM, fam_clust),
-		kins=GRM,
-		family=binomial(link="logit"),
-		infile=bfile,
-		snps=snplist,
-		missing.method="omit")
+# fit null model
+f0 <- glmmkin(fixed = Y~.,data=dat,kins=GRM,family=binomial(link="logit"))
 
 if(testing){
-	print(date())
-	print(head(f0))
-	print(summary(f0$converged))
+        print(date())
 }
+print(f0$theta)
+print(f0$coefficients)
 
-# return NA for non-converged results
-f0[!f0$converged | is.na(f0$converged),c("BETA","SE","PVAL")] <- NA
+# get select vector for NA phenos
+sel <- rep(NA,nrow(dat))
+sel[is.na(dat$Y)] <- 0
+sel[!is.na(dat$Y)] <- 1:sum(!is.na(dat$Y))
 
-# format output
-# flip beta since gmmat returns results for A2 instead of A1
-out <- data.frame(CHR=f0$CHR, 
-		  SNP=f0$SNP, 
-		  POS=f0$POS, 
-		  A1=f0$A1, 
-		  BETA=-1*f0$BETA, 
-		  SE=f0$SE, 
-		  CHISQ=(f0$BETA/f0$SE)^2, 
-		  P=f0$PVAL, 
-		  N=f0$N, 
-		  M_COV=ncol(dat)-1)
-
-# return
-outfile = paste("gmmat.",outstem,".R.txt",sep="")
-write.table(format(out,digits=8), file=outfile, col.names=TRUE, row.names=FALSE, quote=FALSE, sep = ' ')
+# run score tests
+glmm.score(f0,
+	infile = bfile,
+	select = sel,
+	missing.method="omit",
+	outfile = paste("gmmat_score.",outstem,".R.txt",sep=""))
 
 if(testing){
 	print(date())

--- a/bin/gmmat_logit_covar_grmonly.R
+++ b/bin/gmmat_logit_covar_grmonly.R
@@ -1,0 +1,141 @@
+#####################
+# Logistic Mixed Model, using GMMAT
+# - logistic link function
+# - GRM + FID clusters (block diagonal) as variance components
+# - arbitrary covariates
+# - see GMMAT package for references
+#
+# by Raymond Walters
+# May 2016
+#
+# Note: currently no check for invariant covariates 
+#
+#####################
+
+testing <- TRUE
+
+require("GMMAT",lib="~/Rlibs")
+
+# need:
+# plink file stem
+# grm file name (assumed square, with same FID/IIDs as bfile (in order)
+# covar file name (file must have header, with FID and IID)
+# outname
+
+# build:
+# fam_clust
+# list of SNPs
+# order of IDs
+# output file name
+
+# parse arguments
+args = commandArgs(TRUE)
+bfile = as.character(args[1])
+grmfile = as.character(args[2])
+covfile = as.character(args[3])
+outstem = as.character(args[4])
+
+if(testing){
+	print(date())
+	print(args)
+}
+
+# load files
+GRM <- as.matrix(read.table(grmfile))
+fam <- read.table(paste(bfile,".fam",sep=""),stringsAsFactors=FALSE,header=FALSE)
+bim <- read.table(paste(bfile,".bim",sep=""),stringsAsFactors=FALSE,header=FALSE)
+snplist <- bim[,2]
+incov <- as.data.frame(read.table(covfile,header=TRUE))
+
+if(testing){
+	print(date())
+}
+
+# verify GRM is square, same dim as fam
+if(ncol(GRM) != nrow(GRM)){
+	stop("GRM matrix must be square. See e.g. 'plink --make-rel square gz', rather than '--make-grm-gz'.")
+}
+if(nrow(GRM) != nrow(fam)){
+	stop("GRM file should match plink fam file (e.g. number, order of individuals)")
+}
+
+# match ID order
+fam_id <- paste(fam[,1], ":", fam[,2], sep="")
+cov_id <- paste(incov$FID, ":", incov$IID, sep="")
+idx <- match(fam_id, cov_id)
+idna <- is.na(idx)
+
+# build covariate/phenotype matrix
+dat <- as.data.frame(matrix(NA,nrow(fam),ncol(incov)-1))
+colnames(dat) <- c("Y",colnames(incov[,-c(1,2)]))
+dat$Y <- fam[,6]
+dat$Y[dat$Y == -9] <- NA
+dat$Y <- dat$Y - 1 # switch from 1/2 to 0/1 coding 
+dat[!idna,-1] <- incov[idx[!idna],-c(1,2)]
+
+if(testing){
+	print(date())
+	print(dim(dat))
+	print(head(dat))
+}
+
+# build fam_clust
+# block diagonal matrix, indicating IDs in same FID
+# fam_clust <- matrix(NA,nrow(fam),nrow(fam))
+# for(i in 1:nrow(fam)){
+#	for(j in 1:i){
+#		if(fam[i,1]==fam[j,1]){
+#			fam_clust[i,j] <- 1
+#		}else{
+#			fam_clust[i,j] <- 0
+#		}
+#	}
+# }
+# fam_clust[upper.tri(fam_clust)] <- t(fam_clust)[upper.tri(fam_clust)]
+# diag(fam_clust) <- 1
+
+if(testing){
+	print(date())
+}
+
+# fit model
+f0 <- glmm.wald(fixed = Y~.,
+		data=dat,
+#		kins=list(GRM, fam_clust),
+		kins=GRM,
+		family=binomial(link="logit"),
+		infile=bfile,
+		snps=snplist,
+		missing.method="omit")
+
+if(testing){
+	print(date())
+	print(head(f0))
+	print(summary(f0$converged))
+}
+
+# return NA for non-converged results
+f0[!f0$converged,c("BETA","SE","PVAL")] <- NA
+
+# format output
+# flip beta since gmmat returns results for A2 instead of A1
+out <- data.frame(CHR=f0$CHR, 
+		  SNP=f0$SNP, 
+		  POS=f0$POS, 
+		  A1=f0$A1, 
+		  BETA=-1*f0$BETA, 
+		  SE=f0$SE, 
+		  CHISQ=(f0$BETA/f0$SE)^2, 
+		  P=f0$PVAL, 
+		  N=f0$N, 
+		  M_COV=ncol(dat)-1)
+
+# return
+outfile = paste(outstem,".gmmat.R.txt",sep="")
+write.table(format(out,digits=8), file=outfile, col.names=TRUE, row.names=FALSE, quote=FALSE, sep = ' ')
+
+if(testing){
+	print(date())
+}
+
+# eof

--- a/bin/gmmat_logit_covar_grmonly.R
+++ b/bin/gmmat_logit_covar_grmonly.R
@@ -115,7 +115,7 @@ if(testing){
 }
 
 # return NA for non-converged results
-f0[!f0$converged,c("BETA","SE","PVAL")] <- NA
+f0[!f0$converged | is.na(f0$converged),c("BETA","SE","PVAL")] <- NA
 
 # format output
 # flip beta since gmmat returns results for A2 instead of A1

--- a/bin/gmmat_logit_covar_grmonly.R
+++ b/bin/gmmat_logit_covar_grmonly.R
@@ -131,7 +131,7 @@ out <- data.frame(CHR=f0$CHR,
 		  M_COV=ncol(dat)-1)
 
 # return
-outfile = paste(outstem,".gmmat.R.txt",sep="")
+outfile = paste("gmmat.",outstem,".R.txt",sep="")
 write.table(format(out,digits=8), file=outfile, col.names=TRUE, row.names=FALSE, quote=FALSE, sep = ' ')
 
 if(testing){

--- a/bin/gmmat_logit_covar_grmonly.R
+++ b/bin/gmmat_logit_covar_grmonly.R
@@ -12,7 +12,7 @@
 #
 #####################
 
-testing <- TRUE
+testing <- FALSE
 
 require("GMMAT",lib="~/Rlibs")
 

--- a/bin/gmmat_logit_covar_wald.R
+++ b/bin/gmmat_logit_covar_wald.R
@@ -98,26 +98,40 @@ if(testing){
 	print(date())
 }
 
-# fit null model
-f0 <- glmmkin(fixed = Y~.,data=dat,kins=list(GRM,fam_clust),family=binomial(link="logit"))
+# fit model
+f0 <- glmm.wald(fixed = Y~.,
+		data=dat,
+		kins=list(GRM, fam_clust),
+		family=binomial(link="logit"),
+		infile=bfile,
+		snps=snplist,
+		missing.method="omit")
 
 if(testing){
-        print(date())
+	print(date())
+	print(head(f0))
+	print(summary(f0$converged))
 }
-print(f0$theta)
-print(f0$coefficients)
 
-# get select vector for NA phenos
-sel <- rep(NA,nrow(dat))
-sel[is.na(dat$Y)] <- 0
-sel[!is.na(dat$Y)] <- 1:sum(!is.na(dat$Y))
+# return NA for non-converged results
+f0[!f0$converged | is.na(f0$converged),c("BETA","SE","PVAL")] <- NA
 
-# run score tests
-glmm.score(f0,
-	infile = bfile,
-	select = sel,
-	missing.method="omit",
-	outfile = paste("gmmatfam_score.",outstem,".R.txt",sep=""))
+# format output
+# flip beta since gmmat returns results for A2 instead of A1
+out <- data.frame(CHR=f0$CHR, 
+		  SNP=f0$SNP, 
+		  POS=f0$POS, 
+		  A1=f0$A1, 
+		  BETA=-1*f0$BETA, 
+		  SE=f0$SE, 
+		  CHISQ=(f0$BETA/f0$SE)^2, 
+		  P=f0$PVAL, 
+		  N=f0$N, 
+		  M_COV=ncol(dat)-1)
+
+# return
+outfile = paste("gmmatfam.",outstem,".R.txt",sep="")
+write.table(format(out,digits=8), file=outfile, col.names=TRUE, row.names=FALSE, quote=FALSE, sep = ' ')
 
 if(testing){
 	print(date())

--- a/bin/gwas_rel.py
+++ b/bin/gwas_rel.py
@@ -27,7 +27,7 @@ import subprocess
 import os
 from warnings import warn
 from args_gwas import *
-from py_helpers import link, unbuffer_stdout, read_conf
+from py_helpers import link, unbuffer_stdout, read_conf, find_from_path
 unbuffer_stdout()
 
 
@@ -54,8 +54,12 @@ if args.model == 'gee':
     gwas_ex = rp_bin+'/gwas_gee.py'
 elif args.model == 'dfam':
     gwas_ex = rp_bin+'/gwas_dfam.py'
+elif args.model == 'gmmat':
+    gwas_ex = rp_bin+'/gmmat_logit_covar_grmonly.R'
+elif args.model == 'gmmat-fam':
+    gwas_ex = rp_bin+'/gmmat_logit_covar.R'
 else:
-    raise ValueError('Invalid \'--model\'. Must be one of \'gee\' or \'dfam\'.')
+    raise ValueError('Invalid \'--model\'. Must be one of \'gee\', \'dfam\', \'gmmat\', or \'gmmat-fam\'.')
 
 
 # get useful modified args
@@ -101,6 +105,7 @@ print '--snp-chunk '+str(args.snp_chunk)
 print '\nCluster Settings:'
 print '--sleep '+str(args.sleep)
 print '--r-ex '+str(args.r_ex)
+print '--rscript-ex '+str(args.rscript_ex)
 print '--rplink-ex '+str(args.rplink_ex)
 
 # TODO: these
@@ -129,6 +134,10 @@ conf_file = os.environ['HOME']+"/ricopili.conf"
 configs = read_conf(conf_file)
 
 plinkx = configs['p2loc']+"plink"
+
+if args.model == 'gmmat' or args.model == 'gmmat-fam':
+    if args.rscript_ex == None or args.rscript_ex == "None":
+        args.rscript_ex = find_from_path('Rscript', 'Rscript')
 
 
 #############
@@ -212,6 +221,7 @@ for line in chunk_file:
 chunk_file.close()
 print 'Chunk definitions written to %s' % './'+str(outdir)+'/'+str(chunk_file.name)
 
+
 ######################
 print '\n...Dividing SNPs into genomic chunks...'
 ######################
@@ -228,11 +238,17 @@ def find_chunk(snpchrom, snpbp, last_chunk):
 cur_chunk = open(str(outdot)+'.snps.'+str(chunks.keys()[0])+'.txt', 'w')
 last_chunk = str(chunks.keys()[0])
 omitsnp = 0
+# track chrs (for GRM building in gmmat)
+chrs = []
 
 # find chunk for each SNP, write to file
 bim = open(str(args.bfile)+'.bim', 'r')
 for line in bim:
     (chrom, snp, cm, bp, a1, a2) = line.split()
+
+    # reocrd novel chrs
+    if chrom not in chrs:
+        chrs.append(chrom)
 
     # find matching chunk    
     snp_chunk = find_chunk(chrom, bp, last_chunk)
@@ -264,13 +280,116 @@ if omitsnp > 0:
 
 
 ######################
+if args.model == 'gmmat' or args.model == 'gmmat-fam':
+    print '\n...Building GRMs for mixed model (leave-one-chromosome-out)...'
+######################  
+    
+    for ch in xrange(1,23):
+        # skip for chromosomes with no data
+        if ch not in chrs:
+            continue
+
+        # verify file doesn't already exist        
+        grm_file = 'grm.'+str(outdot)+'.loco_chr'+str(chr)+'.rel.gz'
+        if not os.path.isfile(str(grm_file)):
+            grm_call = [plinkx,
+                        '--bfile',str(args.bfile),
+                        '--make-rel','square','gz',
+                        '--autosome',
+                        '--not-chr',str(ch),
+                        '--out','grm.'+str(outdot)+'.loco_chr'+str(chr)]
+    
+            if args.keep is not None:
+                grm_call.extend(['--keep',str(args.keep)])
+            elif args.remove is not None:
+                grm_call.extend(['--remove',str(args.remove)])     
+
+            # run plink, keep log
+            grm_log = open('grm.'+str(outdot)+'.loco_chr'+str(chr)+'.plink.log', 'w')
+            subprocess.check_call(frq_call, stderr=subprocess.STDOUT, stdout=grm_log)
+            grm_log.close()
+            print 'Created GRM omitting chr %d: %s' % (int(ch), str(grm_file))
+        
+        # log in case existing file found
+        else:
+            print 'Found existing GRM omitting chr %d: %s' % (int(ch), str(grm_file))
+
+
+
+######################
+    if args.covar is not None:
+        print '\n...Preparing covariates...' 
+        # only for gmmat, plink handles covariates
+######################
+
+        cov_in = open(str(args.covar), 'r')
+        covhead = cov_in.readline().split()
+        
+        if 'FID' not in covhead or 'IID' not in covhead:
+            ValueError('Covariate file is missing header with FID and IID (required for GMMAT).')
+    
+        # extract covariates to use, if necessary        
+        if args.covar_number is not None:
+            cov_out = open(str(args.covar)+'.sub.txt', 'w')
+            
+            # split eg. 1-10,12
+            cov1 = [x.split(',') for x in args.covar_number]
+    
+            # flatten list of lists
+            cov2 = [item for sublist in cov1 for item in sublist]
+            
+            # remove empty strings
+            cov3 = [x.replace(',','') for x in cov2 if x is not None and str(x) != '']
+    
+            # interpret ranges
+            # credit: http://stackoverflow.com/questions/6405208/how-to-convert-numeric-string-ranges-to-a-list-in-python
+            covnum = []
+            for part in cov3:
+                    if '-' in part:
+                            a, b = part.split('-')
+                            a, b = int(a), int(b)
+                            covnum.extend(range(a, b+1))
+                    else:
+                            a = int(part)
+                            covnum.append(a)
+    
+            abscol = [0, 1]
+            # +1 here is +2 for FID/IID cols, -1 for python's base-0 index
+            abscol.extend([x+1 for x in covnum])
+    
+            # write header line
+            head_out = ' '.join([str(covhead[int(x)]) for x in abscol])
+            cov_out.write(head_out + '\n')
+    
+            # write data lines
+            for line in cov_in:
+                line_out = ' '.join([str(line.split()[int(x)]) for x in abscol])
+                cov_out.write(line_out + '\n')
+            
+            cov_out.close()
+            cov_in.close()
+            
+        else:
+            cov_in.close()
+        
+    # no covariates
+    else:
+        raise ValueError('GMMAT without covariates not currently implemented.\n')
+
+
+
+
+
+######################
 print '\n...Submitting GWAS for all chunks...'
 ######################
 
 # gwas each chunk
 # need to write submit script to include chunk name parsing
 # TODO: consider making queue/resources flexible
-uger_gwas_template = """#!/usr/bin/env sh
+
+if args.model == 'gee' or args.model == 'dfam':
+    uger_gwas_template = """#!/usr/bin/env sh
 #$ -j y
 #$ -cwd
 #$ -V
@@ -293,24 +412,65 @@ cname=`awk -v a=${{SGE_TASK_ID}} 'NR==a+1{{print $4}}' {cfile}`
 
 # eof
 """
+
+# alternative template for GMMAT
+# Rscript --no-save --no-restore 
+# ~/github/picopili/bin/gmmat_logit_covar.R 
+# fgwa.chr15_073_077_head               (bfile stem)
+# fgw_grm_loco15.rel.gz                 (square GRM from plink matching bfile)
+# ../fgwa_eur_1KGp3_postimp.pca.txt     (covariate file)
+# test1                                 (output name)
+# > test_gmm.log
+elif args.model == 'gmmat' or args.model == 'gmmat-fam':
+    uger_gwas_template = """#!/usr/bin/env sh
+#$ -j y
+#$ -cwd
+#$ -V
+#$ -N {jname}
+#$ -q short
+#$ -l m_mem_free=4g
+#$ -t 1-{nchunk}
+#$ -tc 200
+#$ -o {outlog}
+
+source /broad/software/scripts/useuse
+sleep {sleep}
+
+cname=`awk -v a=${{SGE_TASK_ID}} 'NR==a+1{{print $4}}' {cfile}`
+chrnum=`awk -v a=${{SGE_TASK_ID}} 'NR==a+1{{print $1}}' {cfile}`
+
+{plinkx} --bfile {bfile} --extract {outdot}.snps.${{cname}}.txt {optargs} --make-bed {outdot}.${{cname}}
+
+{rsc} --no-save --no-restore {gwas_ex} {outdot}.${{cname}} grm.{outdot}.loco_chr${{chrnum}}.rel.gz {covarsub} {outdot}.${{cname}} > {outdot}.${{cname}}.gmmat.R.log
+
+# eof
+"""
+
+
 gwasargs = ''
-if args.addout is not None:
-    gwasargs = gwasargs + ' --addout '+str(args.addout)+'.${cname}'
-else:
-    gwasargs = gwasargs + ' --addout ${cname}'
+
 if args.pheno is not None:
     gwasargs = gwasargs + ' --pheno '+str(args.pheno)
-if args.covar is not None:
-    gwasargs = gwasargs + ' --covar '+str(args.covar)
-if args.covar_number is not None:
-    gwasargs = gwasargs + ' --covar-number '+' '.join(args.covar_number)
 if args.keep is not None:
     gwasargs = gwasargs + ' --keep '+str(args.keep)
 if args.remove is not None:
     gwasargs = gwasargs + ' --remove '+str(args.remove)
 
-gwasargs = gwasargs + ' --r-ex '+str(args.r_ex)+' --rplink-ex '+str(args.rplink_ex)
+# these args not passed for gmmat
+if args.model == 'gee' or args.model == 'dfam':
+    if args.addout is not None:
+        gwasargs = gwasargs + ' --addout '+str(args.addout)+'.${cname}'
+    else:
+        gwasargs = gwasargs + ' --addout ${cname}'
+    if args.covar is not None:
+        gwasargs = gwasargs + ' --covar '+str(args.covar)
+    if args.covar_number is not None:
+        gwasargs = gwasargs + ' --covar-number '+' '.join(args.covar_number)
+
+    gwasargs = gwasargs + ' --r-ex '+str(args.r_ex)+' --rplink-ex '+str(args.rplink_ex)
+
 # TODO: pass through cleanup
+
     
 nchunk = len(chunks.keys())
 jobdict = {"jname": 'gwas.chunks.'+str(outdot),
@@ -323,7 +483,10 @@ jobdict = {"jname": 'gwas.chunks.'+str(outdot),
            "bfile": str(args.bfile),
            "argout": str(args.out),
            "outdot": str(outdot),
-           "optargs": str(gwasargs)
+           "optargs": str(gwasargs),
+           "plinkx": str(plinkx),
+           "covarsub": str(args.covar)+'.sub.txt',
+           "rsc": str(args.rscript_ex)
            }
 
 # for gee, need to specify Rserve port for each job
@@ -332,6 +495,7 @@ jobdict = {"jname": 'gwas.chunks.'+str(outdot),
 if args.model == 'gee':
     jobdict['misc'] = 'rport=$((49151+SGE_TASK_ID))'
     jobdict['optargs'] = str(gwasargs) +' --port $rport'
+
 
 uger_gwas = open(str(outdot)+'.gwas_chunks.sub.sh', 'w')
 uger_gwas.write(uger_gwas_template.format(**jobdict))

--- a/bin/gwas_rel.py
+++ b/bin/gwas_rel.py
@@ -72,10 +72,14 @@ else:
     addout_txt = ['','']
     outdot = str(args.out)
 
+if args.strict_bfile is None or str(args.strict_bfile) == "None":
+    args.strict_bfile = str(args.bfile)
 
 # report settings in use
 print '\nBasic settings:'
 print '--bfile '+str(args.bfile)
+if args.model == 'gmmat' or args.model == 'gmmat-fam':
+    print '--strict-bfile '+str(args.strict_bfile)
 print '--out '+str(args.out)
 if args.addout is not None:
     print '--addout '+str(args.addout)
@@ -167,6 +171,11 @@ os.chdir(outdir)
 link(wd+'/'+str(args.bfile)+'.bed', str(args.bfile)+'.bed', 'input plink bed file')
 link(wd+'/'+str(args.bfile)+'.bim', str(args.bfile)+'.bim', 'input plink bim file')
 link(wd+'/'+str(args.bfile)+'.fam', str(args.bfile)+'.fam', 'input plink fam file')
+
+if str(args.strict_bfile) != str(args.bfile):
+    link(wd+'/'+str(args.strict_bfile)+'.bed', str(args.strict_bfile)+'.bed', 'plink bed file for GRM')
+    link(wd+'/'+str(args.strict_bfile)+'.bim', str(args.strict_bfile)+'.bim', 'plink bim file for GRM')
+    link(wd+'/'+str(args.strict_bfile)+'.fam', str(args.strict_bfile)+'.fam', 'plink fam file for GRM')
 
 if args.covar is not None and str(args.covar) != "None":
     link(wd+'/'+str(args.covar), str(args.covar), 'covariate file')
@@ -293,8 +302,11 @@ if args.model == 'gmmat' or args.model == 'gmmat-fam':
         grm_file = 'grm.'+str(outdot)+'.loco_chr'+str(ch)+'.rel.gz'
         if not os.path.isfile(str(grm_file)):
             grm_call = [plinkx,
-                        '--bfile',str(args.bfile),
+                        '--bfile',str(args.strict_bfile),
+                        '--maf',str(.01),
+                        '--geno', str(.01),                        
                         '--make-rel','square','gz',
+                        '--make-founders',
                         '--autosome',
                         '--not-chr',str(ch),
                         '--out','grm.'+str(outdot)+'.loco_chr'+str(ch)]


### PR DESCRIPTION
Add support for using logistic mixed model for gwas, using the R package GMMAT.

Access using `--model gmmat` (mixed component is GRM only) or `--model gmmat-fam` (mixed components for GRM and common environment within-family. 

Currently defaulting to score test from mixed model. R scripts are present for Wald test alternative, but don't have corresponding model argument or results aggregation.