### PR TITLE
make strict-bfile optional (only used for gmmat)

### DIFF
--- a/bin/args_gwas.py
+++ b/bin/args_gwas.py
@@ -88,7 +88,7 @@ arg_test.add_argument('--strict-bfile',
 		      metavar='FILESTEM',
 		      help='(GMMAT model only) file stem for input plink bed/bim/fam used to compute GRM. ' + \
 		           'Defaults to using --bfile with MAF > .01, missing < .01 if unspecified.',
-		      required=True)
+		      required=False)
 arg_subset.add_argument('--keep',
                     type=str,
                     metavar='FILE',


### PR DESCRIPTION
Default handling if `--strict-bfile` is unspecified with `--model gmmat` is already specified and documented in `--help` (uses gwas bfile, with mild filtering).